### PR TITLE
Add support for accepting error objects directly in logging functions

### DIFF
--- a/logerr_test.go
+++ b/logerr_test.go
@@ -80,10 +80,10 @@ func TestLogMessages(t *testing.T) {
 	logger.Level = LogLevelDebug // Make sure all messages are logged
 	logger.NoColor = true        // Disable colors for testing
 
-	// Test basic logging methods
+	// Test basic logging methods with string
 	tests := []struct {
-		logFunc   func(string)
-		message   string
+		logFunc   func(any)
+		message   any
 		levelText string
 	}{
 		{logger.Debug, "debug test", "[DEBUG]"},
@@ -96,9 +96,39 @@ func TestLogMessages(t *testing.T) {
 		buf.Reset()
 		test.logFunc(test.message)
 		output := buf.String()
-		if !strings.Contains(output, test.levelText) || !strings.Contains(output, test.message) {
+		messageStr, ok := test.message.(string)
+		if !ok {
+			messageStr = fmt.Sprintf("%v", test.message)
+		}
+		if !strings.Contains(output, test.levelText) || !strings.Contains(output, messageStr) {
 			t.Errorf("Expected message to contain '%s' and '%s', got: %s",
-				test.levelText, test.message, output)
+				test.levelText, messageStr, output)
+		}
+	}
+
+	// Test basic logging methods with error
+	errorTests := []struct {
+		logFunc   func(any)
+		message   any
+		levelText string
+	}{
+		{logger.Debug, errors.New("debug error"), "[DEBUG]"},
+		{logger.Info, errors.New("info error"), "[INFO]"},
+		{logger.Warn, errors.New("warn error"), "[WARN]"},
+		{logger.Error, errors.New("error error"), "[ERROR]"},
+	}
+
+	for _, test := range errorTests {
+		buf.Reset()
+		test.logFunc(test.message)
+		output := buf.String()
+		err, ok := test.message.(error)
+		if !ok {
+			t.Fatalf("Test message is not an error: %v", test.message)
+		}
+		if !strings.Contains(output, test.levelText) || !strings.Contains(output, err.Error()) {
+			t.Errorf("Expected message to contain '%s' and '%s', got: %s",
+				test.levelText, err.Error(), output)
 		}
 	}
 
@@ -124,6 +154,34 @@ func TestLogMessages(t *testing.T) {
 			t.Errorf("Expected formatted message to contain '%s' and '%s', got: %s",
 				test.levelText, test.expected, output)
 		}
+	}
+	
+	// Test formatted logging with error arguments
+	err := errors.New("formatted error")
+	
+	// Test each formatted log function with error argument
+	buf.Reset()
+	logger.Debugf("Got error: %v", err)
+	if !strings.Contains(buf.String(), "Got error: formatted error") {
+		t.Errorf("Expected Debugf with error to contain error message, got: %s", buf.String())
+	}
+	
+	buf.Reset()
+	logger.Infof("Error occurred: %s", err)
+	if !strings.Contains(buf.String(), "Error occurred: formatted error") {
+		t.Errorf("Expected Infof with error to contain error message, got: %s", buf.String())
+	}
+	
+	buf.Reset()
+	logger.Warnf("Warning with error: %s", err)
+	if !strings.Contains(buf.String(), "Warning with error: formatted error") {
+		t.Errorf("Expected Warnf with error to contain error message, got: %s", buf.String())
+	}
+	
+	buf.Reset()
+	logger.Errorf("Error details: %s", err)
+	if !strings.Contains(buf.String(), "Error details: formatted error") {
+		t.Errorf("Expected Errorf with error to contain error message, got: %s", buf.String())
 	}
 
 	// Restore original output
@@ -225,7 +283,7 @@ func TestErrorWrapping(t *testing.T) {
 	logger := DefaultLogger().SetContext("test-context")
 	logger.LogWrappedErrors = true
 
-	// Test error wrapping
+	// Test error wrapping with error type
 	originalErr := errors.New("original error")
 	wrappedErr := logger.Wrap(originalErr)
 
@@ -239,6 +297,26 @@ func TestErrorWrapping(t *testing.T) {
 	if !errors.Is(wrappedErr, originalErr) {
 		t.Errorf("Expected wrapped error to contain original error")
 	}
+
+	// Test wrapping with string type
+	errString := "string error"
+	wrappedStringErr := logger.Wrap(errString)
+	expectedString := "test-context | " + errString
+	if wrappedStringErr.Error() != expectedString {
+		t.Errorf("Expected wrapped string error '%s', got '%s'", expectedString, wrappedStringErr.Error())
+	}
+	
+	// Test wrapping with other type (int)
+	intVal := 42
+	wrappedIntErr := logger.Wrap(intVal)
+	expectedIntString := "test-context | 42"
+	if wrappedIntErr.Error() != expectedIntString {
+		t.Errorf("Expected wrapped int error '%s', got '%s'", expectedIntString, wrappedIntErr.Error())
+	}
+	
+	// Test with LogWrappedErrors disabled
+	logger.LogWrappedErrors = false
+	logger.Wrap(originalErr) // Should not log the error
 }
 
 func TestColorControl(t *testing.T) {
@@ -284,7 +362,7 @@ func TestGlobalFunctions(t *testing.T) {
 	// Set as global logger
 	testLogger.SetAsGlobal()
 
-	// Test global functions
+	// Test global functions with string messages
 	Debug("global debug")
 	if !strings.Contains(buf.String(), "global debug") {
 		t.Errorf("Global Debug function failed to log message")
@@ -333,10 +411,47 @@ func TestGlobalFunctions(t *testing.T) {
 	}
 	buf.Reset()
 
+	// Test global functions with error messages
+	debugErr := errors.New("debug error")
+	Debug(debugErr)
+	if !strings.Contains(buf.String(), debugErr.Error()) {
+		t.Errorf("Global Debug function failed to log error message")
+	}
+	buf.Reset()
+
+	infoErr := errors.New("info error")
+	Info(infoErr)
+	if !strings.Contains(buf.String(), infoErr.Error()) {
+		t.Errorf("Global Info function failed to log error message")
+	}
+	buf.Reset()
+
+	warnErr := errors.New("warn error")
+	Warn(warnErr)
+	if !strings.Contains(buf.String(), warnErr.Error()) {
+		t.Errorf("Global Warn function failed to log error message")
+	}
+	buf.Reset()
+
+	errorErr := errors.New("error error")
+	Error(errorErr)
+	if !strings.Contains(buf.String(), errorErr.Error()) {
+		t.Errorf("Global Error function failed to log error message")
+	}
+	buf.Reset()
+
 	// We can't test Fatal and Fatalf since they call os.Exit
 
 	// Test global context functions
+	// Test SetContext global function
 	SetContext("global context")
+	// The SetContext function updates the global logger internally
+	
+	// Test global Context() function
+	contextStr := Context()
+	if contextStr != "global context" {
+		t.Errorf("Global Context() failed. Expected 'global context', got '%s'", contextStr)
+	}
 
 	// Create a new logger with additional context
 	logger := Add("additional context")
@@ -344,13 +459,26 @@ func TestGlobalFunctions(t *testing.T) {
 		t.Errorf("Global Add failed")
 	}
 
+	// Test global ClearContext function
 	ClearContext()
+	
+	// Verify context is cleared
+	contextStr = Context()
+	if contextStr != "" {
+		t.Errorf("Global Context() after clear failed. Expected empty string, got '%s'", contextStr)
+	}
 
-	// Test global error wrapping
+	// Test global error wrapping with error type
 	err := errors.New("test error")
 	wrappedErr := Wrap(err)
 	if !errors.Is(wrappedErr, err) {
 		t.Errorf("Global Wrap failed to preserve original error")
+	}
+
+	// Test global error wrapping with string
+	strWrappedErr := Wrap("string error")
+	if !strings.Contains(strWrappedErr.Error(), "string error") {
+		t.Errorf("Global Wrap failed to handle string input")
 	}
 
 	// Test global color control
@@ -379,6 +507,49 @@ func TestFormatLogMessage(t *testing.T) {
 	expected = "[INFO] test context | test message"
 	if message != expected {
 		t.Errorf("Expected formatLogMessage with context to return %q, got %q", expected, message)
+	}
+}
+
+func TestMessageToString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    any
+		expected string
+	}{
+		{
+			name:     "string input",
+			input:    "test string",
+			expected: "test string",
+		},
+		{
+			name:     "error input",
+			input:    errors.New("test error"),
+			expected: "test error",
+		},
+		{
+			name:     "integer input",
+			input:    123,
+			expected: "123",
+		},
+		{
+			name:     "boolean input",
+			input:    true,
+			expected: "true",
+		},
+		{
+			name:     "struct input",
+			input:    struct{ Name string }{"test"},
+			expected: "{test}",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := messageToString(test.input)
+			if result != test.expected {
+				t.Errorf("messageToString(%v) = %q, expected %q", test.input, result, test.expected)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
- Accept error types as message parameter in all logging functions
- Add messageToString utility to convert any type to string
- Update Wrap() function to handle strings and other types
- Fix SetContext global wrapper function to properly update global logger
- Add comprehensive tests for error handling in all functions
- Improve test coverage to over 90%