### PR TITLE
variadic args, timestamps, and custom context separator

### DIFF
--- a/logerr.go
+++ b/logerr.go
@@ -24,10 +24,10 @@ const (
 
 // String labels for each log level
 var labels = map[LogLevel]string{
-	LogLevelDebug: "DEBUG",
-	LogLevelInfo:  "INFO",
-	LogLevelWarn:  "WARN",
-	LogLevelError: "ERROR",
+	LogLevelDebug: "DBG",
+	LogLevelInfo:  "INF",
+	LogLevelWarn:  "WRN",
+	LogLevelError: "ERR",
 	LogLevelFatal: "FATAL",
 }
 
@@ -132,7 +132,7 @@ func (l Logger) Wrap(val any) error {
 	default:
 		err = fmt.Errorf("%v", v)
 	}
-	
+
 	if l.LogWrappedErrors {
 		l.Error(err)
 	}
@@ -169,10 +169,28 @@ func messageToString(message any) string {
 }
 
 // log outputs a message if it should be logged based on level
-// message can be a string or an error
-func (l *Logger) log(level LogLevel, message any) {
+// first argument can be a string or an error, any additional arguments are appended
+func (l *Logger) log(level LogLevel, args ...any) {
 	if l.shouldLog(level) {
-		msgStr := messageToString(message)
+		if len(args) == 0 {
+			// No arguments provided
+			return
+		}
+
+		// Format the message based on the number of arguments
+		var msgStr string
+		if len(args) == 1 {
+			// Single argument case (backwards compatibility)
+			msgStr = messageToString(args[0])
+		} else {
+			// Multiple arguments case
+			msgParts := make([]string, len(args))
+			for i, arg := range args {
+				msgParts[i] = messageToString(arg)
+			}
+			msgStr = strings.Join(msgParts, " ")
+		}
+
 		formatted := l.formatLogMessage(level, msgStr)
 		fmt.Fprintln(l.Output, formatted)
 	}
@@ -186,9 +204,9 @@ func (l *Logger) logf(level LogLevel, format string, args ...any) {
 }
 
 // Debug logs a message at DEBUG level
-// message can be a string or an error
-func (l Logger) Debug(message any) {
-	l.log(LogLevelDebug, message)
+// First argument can be a string or an error, any additional arguments are appended
+func (l Logger) Debug(args ...any) {
+	l.log(LogLevelDebug, args...)
 }
 
 // Debugf logs a formatted message at DEBUG level
@@ -197,9 +215,9 @@ func (l Logger) Debugf(format string, args ...any) {
 }
 
 // Info logs a message at INFO level
-// message can be a string or an error
-func (l Logger) Info(message any) {
-	l.log(LogLevelInfo, message)
+// First argument can be a string or an error, any additional arguments are appended
+func (l Logger) Info(args ...any) {
+	l.log(LogLevelInfo, args...)
 }
 
 // Infof logs a formatted message at INFO level
@@ -208,9 +226,9 @@ func (l Logger) Infof(format string, args ...any) {
 }
 
 // Warn logs a message at WARN level
-// message can be a string or an error
-func (l Logger) Warn(message any) {
-	l.log(LogLevelWarn, message)
+// First argument can be a string or an error, any additional arguments are appended
+func (l Logger) Warn(args ...any) {
+	l.log(LogLevelWarn, args...)
 }
 
 // Warnf logs a formatted message at WARN level
@@ -219,9 +237,9 @@ func (l Logger) Warnf(format string, args ...any) {
 }
 
 // Error logs a message at ERROR level
-// message can be a string or an error
-func (l Logger) Error(message any) {
-	l.log(LogLevelError, message)
+// First argument can be a string or an error, any additional arguments are appended
+func (l Logger) Error(args ...any) {
+	l.log(LogLevelError, args...)
 }
 
 // Errorf logs a formatted message at ERROR level
@@ -230,9 +248,9 @@ func (l Logger) Errorf(format string, args ...any) {
 }
 
 // Fatal logs a message at FATAL level and exits the program
-// message can be a string or an error
-func (l Logger) Fatal(message any) {
-	l.log(LogLevelFatal, message)
+// First argument can be a string or an error, any additional arguments are appended
+func (l Logger) Fatal(args ...any) {
+	l.log(LogLevelFatal, args...)
 	os.Exit(1)
 }
 
@@ -256,36 +274,36 @@ func formatLabel(level LogLevel, noColor bool) string {
 // Global convenience functions that use the default logger
 
 // Debug logs a message at DEBUG level using the global logger
-// message can be a string or an error
-func Debug(message any) { G.Debug(message) }
+// First argument can be a string or an error, any additional arguments are appended
+func Debug(args ...any) { G.Debug(args...) }
 
 // Debugf logs a formatted message at DEBUG level using the global logger
 func Debugf(format string, vals ...any) { G.Debugf(format, vals...) }
 
 // Info logs a message at INFO level using the global logger
-// message can be a string or an error
-func Info(message any) { G.Info(message) }
+// First argument can be a string or an error, any additional arguments are appended
+func Info(args ...any) { G.Info(args...) }
 
 // Infof logs a formatted message at INFO level using the global logger
 func Infof(format string, vals ...any) { G.Infof(format, vals...) }
 
 // Warn logs a message at WARN level using the global logger
-// message can be a string or an error
-func Warn(message any) { G.Warn(message) }
+// First argument can be a string or an error, any additional arguments are appended
+func Warn(args ...any) { G.Warn(args...) }
 
 // Warnf logs a formatted message at WARN level using the global logger
 func Warnf(format string, vals ...any) { G.Warnf(format, vals...) }
 
 // Error logs a message at ERROR level using the global logger
-// message can be a string or an error
-func Error(message any) { G.Error(message) }
+// First argument can be a string or an error, any additional arguments are appended
+func Error(args ...any) { G.Error(args...) }
 
 // Errorf logs a formatted message at ERROR level using the global logger
 func Errorf(format string, vals ...any) { G.Errorf(format, vals...) }
 
 // Fatal logs a message at FATAL level and exits the program using the global logger
-// message can be a string or an error
-func Fatal(message any) { G.Fatal(message) }
+// First argument can be a string or an error, any additional arguments are appended
+func Fatal(args ...any) { G.Fatal(args...) }
 
 // Fatalf logs a formatted message at FATAL level and exits the program using the global logger
 func Fatalf(format string, vals ...any) { G.Fatalf(format, vals...) }

--- a/logerr.go
+++ b/logerr.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/fatih/color"
 )
@@ -64,6 +65,9 @@ type Logger struct {
 
 	// NoColor disables colored output when true
 	NoColor bool
+
+	// ShowTimestamps adds timestamps to log messages when true
+	ShowTimestamps bool
 
 	// ContextSeparator is used to join context elements
 	// Defaults to " | "
@@ -131,6 +135,18 @@ func (l *Logger) SetContextSeparator(separator string) *Logger {
 	return l
 }
 
+// EnableTimestamps enables timestamps in log messages
+func (l *Logger) EnableTimestamps() *Logger {
+	l.ShowTimestamps = true
+	return l
+}
+
+// DisableTimestamps disables timestamps in log messages
+func (l *Logger) DisableTimestamps() *Logger {
+	l.ShowTimestamps = false
+	return l
+}
+
 // Wrap wraps an error with the current context
 // If a string is provided, it will be converted to an error
 func (l Logger) Wrap(val any) error {
@@ -160,6 +176,11 @@ func (l *Logger) shouldLog(level LogLevel) bool {
 func (l *Logger) formatLogMessage(level LogLevel, msg string) string {
 	prefix := formatLabel(level, l.NoColor)
 	ctx := l.Context()
+
+	var timestamp string
+	if l.ShowTimestamps {
+		timestamp = time.Now().Format("2006-01-02 15:04:05.000 ")
+	}
 
 	if ctx == "" {
 		return fmt.Sprintf("%s%s%s", timestamp, prefix, msg)
@@ -341,3 +362,9 @@ func EnableColors() { G.EnableColors() }
 
 // SetContextSeparator sets the separator used for joining context elements for the global logger
 func SetContextSeparator(separator string) { G = G.SetContextSeparator(separator) }
+
+// EnableTimestamps enables timestamps in log messages for the global logger
+func EnableTimestamps() { G = G.EnableTimestamps() }
+
+// DisableTimestamps disables timestamps in log messages for the global logger
+func DisableTimestamps() { G = G.DisableTimestamps() }


### PR DESCRIPTION
This pull request introduces several enhancements and updates to the `logerr` package, focusing on improving functionality, flexibility, and usability. Key changes include support for custom context separators, optional timestamps in log messages, variadic log methods for handling multiple arguments, and updates to log level labels. Additionally, the test suite has been expanded to cover these new features.

### Logger Enhancements:
* Added the `ShowTimestamps` option to include timestamps in log messages and corresponding methods `EnableTimestamps` and `DisableTimestamps`. [[1]](diffhunk://#diff-0097a66d3051ac5ea895f53c3223079e1c9a3c2160b0b3467334f2f164866b67R68-R74) [[2]](diffhunk://#diff-0097a66d3051ac5ea895f53c3223079e1c9a3c2160b0b3467334f2f164866b67R132-R149) [[3]](diffhunk://#diff-0097a66d3051ac5ea895f53c3223079e1c9a3c2160b0b3467334f2f164866b67R180-R189) [[4]](diffhunk://#diff-0097a66d3051ac5ea895f53c3223079e1c9a3c2160b0b3467334f2f164866b67R362-R370)
* Introduced `ContextSeparator` for customizing the separator between context elements, with a default value of `" | "`. Added `SetContextSeparator` method for configuration. [[1]](diffhunk://#diff-0097a66d3051ac5ea895f53c3223079e1c9a3c2160b0b3467334f2f164866b67R68-R74) [[2]](diffhunk://#diff-0097a66d3051ac5ea895f53c3223079e1c9a3c2160b0b3467334f2f164866b67R83) [[3]](diffhunk://#diff-0097a66d3051ac5ea895f53c3223079e1c9a3c2160b0b3467334f2f164866b67L87-R96) [[4]](diffhunk://#diff-0097a66d3051ac5ea895f53c3223079e1c9a3c2160b0b3467334f2f164866b67L139-R167) [[5]](diffhunk://#diff-0097a66d3051ac5ea895f53c3223079e1c9a3c2160b0b3467334f2f164866b67R362-R370)

### Variadic Log Methods:
* Updated log methods (`Debug`, `Info`, `Warn`, `Error`, `Fatal`, and their global counterparts) to support variadic arguments, allowing multiple values to be logged in a single call. [[1]](diffhunk://#diff-0097a66d3051ac5ea895f53c3223079e1c9a3c2160b0b3467334f2f164866b67L172-R226) [[2]](diffhunk://#diff-0097a66d3051ac5ea895f53c3223079e1c9a3c2160b0b3467334f2f164866b67L189-R242) [[3]](diffhunk://#diff-0097a66d3051ac5ea895f53c3223079e1c9a3c2160b0b3467334f2f164866b67L259-R339)

### Log Level Label Updates:
* Simplified log level labels: `DEBUG` → `DBG`, `INFO` → `INF`, `WARN` → `WRN`, and `ERROR` → `ERR`. Updated related tests to reflect these changes. [[1]](diffhunk://#diff-0097a66d3051ac5ea895f53c3223079e1c9a3c2160b0b3467334f2f164866b67L27-R31) [[2]](diffhunk://#diff-a9d79ca0cadb172d94fffc7ab4f9969ce1708059656325e61dbf8bfe962c3626L30-R33) [[3]](diffhunk://#diff-a9d79ca0cadb172d94fffc7ab4f9969ce1708059656325e61dbf8bfe962c3626L83-R108) [[4]](diffhunk://#diff-a9d79ca0cadb172d94fffc7ab4f9969ce1708059656325e61dbf8bfe962c3626L211-R267)

### Testing Improvements:
* Expanded test coverage to validate new features, including custom context separators, variadic log methods, and timestamp functionality. [[1]](diffhunk://#diff-a9d79ca0cadb172d94fffc7ab4f9969ce1708059656325e61dbf8bfe962c3626R70-R85) [[2]](diffhunk://#diff-a9d79ca0cadb172d94fffc7ab4f9969ce1708059656325e61dbf8bfe962c3626R151-R181) [[3]](diffhunk://#diff-a9d79ca0cadb172d94fffc7ab4f9969ce1708059656325e61dbf8bfe962c3626R367-R374)
* Removed the unused `TestFormatLabel` test for better test suite clarity.